### PR TITLE
Allow port configuration via environment variable

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -8,7 +8,7 @@ import dotenv from 'dotenv';
 
 
 dotenv.config();
-const PORT = 3200; // Allow dynamic port configuration
+const PORT = process.env.PORT || 3200; // Allow dynamic port configuration via environment variable
 
 app.listen(PORT, () => {
   console.log(`Server is running on http://localhost:${PORT}`);


### PR DESCRIPTION
## Summary
- allow backend port to be set via PORT environment variable
- document dynamic port configuration through environment variable

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1020d62a4832eb49ca1ab86a41e32